### PR TITLE
feat: support loading custom job definitions, add sample job defs

### DIFF
--- a/helm/nv.svc.farm/files/job_definitions/df.json
+++ b/helm/nv.svc.farm/files/job_definitions/df.json
@@ -1,0 +1,19 @@
+
+{
+    "name": "df",
+    "job_type": "base",
+    "command": "/bin/df",
+    "args": [],
+    "task_function": "",
+    "env": {},
+    "log_to_stdout": true,
+    "extension_paths": [],
+    "allowed_args": {},
+    "headless": true,
+    "active": true,
+    "unresolved_command_path": "/bin/df",
+    "success_return_codes": [0],
+    "capacity_requirements": {},
+    "working_directory": "",
+    "container": "busybox:1.35"
+}

--- a/helm/nv.svc.farm/files/job_definitions/echo.json
+++ b/helm/nv.svc.farm/files/job_definitions/echo.json
@@ -1,0 +1,22 @@
+{
+    "name": "echo",
+    "job_type": "base",
+    "command": "sh",
+    "args": [
+        "-c",
+        "echo \"${1:-This is the default echo message. To modify it, specify <task_args.message> in your task submission.}\"",
+        "sh"
+    ],
+    "allowed_args": {
+        "message": {
+            "arg": "2"
+        }
+    },
+    "headless": true,
+    "active": true,
+    "unresolved_command_path": "sh",
+    "success_return_codes": [0],
+    "capacity_requirements": {},
+    "working_directory": "",
+    "container": "ubuntu:24.04"
+}

--- a/helm/nv.svc.farm/files/job_definitions/nvidia-smi-check.json
+++ b/helm/nv.svc.farm/files/job_definitions/nvidia-smi-check.json
@@ -1,0 +1,24 @@
+{
+    "name": "nvidia-smi-check",
+    "job_type": "base",
+    "command": "nvidia-smi",
+    "args": [],
+    "task_function": "",
+    "env": {},
+    "log_to_stdout": true,
+    "extension_paths": [],
+    "allowed_args": {},
+    "headless": true,
+    "active": true,
+    "unresolved_command_path": "nvidia-smi",
+    "success_return_codes": [0],
+    "capacity_requirements": {
+      "resource_limits": {
+        "cpu": 1,
+        "memory": "4096Mi",
+        "nvidia.com/gpu": 1
+      }
+    },
+    "working_directory": "",
+    "container": "nvidia/cuda:12.2.0-base-ubuntu20.04"
+}

--- a/helm/nv.svc.farm/files/job_definitions/slack-webhook-message.json
+++ b/helm/nv.svc.farm/files/job_definitions/slack-webhook-message.json
@@ -1,0 +1,38 @@
+{
+    "name": "slack-webhook-message",
+    "job_type": "base",
+    "command": "sh",
+    "args": [
+        "-c",
+        "curl -X POST \"$SLACK_WEBHOOK_URL\" -H \"Content-Type: application/json\" -d {\\\"text\\\":\\\"\"${1:-This is the default Slack webhook message. To modify it, specify <task_args.message> in your task submission.}\"\\\"}",
+        "sh"
+    ],
+    "allowed_args": {
+        "message": {
+            "arg": "2"
+        }
+    },
+    "task_function": "",
+    "env": {},
+    "log_to_stdout": true,
+    "extension_paths": [],
+    "headless": true,
+    "active": true,
+    "unresolved_command_path": "sh",
+    "success_return_codes": [0],
+    "capacity_requirements": {
+        "env": [
+            {
+                "name": "SLACK_WEBHOOK_URL",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "key": "SLACK_WEBHOOK_URL",
+                        "name": "slack-webhook-url"
+                    }
+                }
+            }
+        ]
+    },
+    "working_directory": "",
+    "container": "curlimages/curl:8.15.0"
+}

--- a/helm/nv.svc.farm/files/job_definitions/sleep-test.json
+++ b/helm/nv.svc.farm/files/job_definitions/sleep-test.json
@@ -1,0 +1,18 @@
+{
+    "name": "sleep-test",
+    "job_type": "base",
+    "command": "sleep",
+    "args": ["60"],
+    "task_function": "",
+    "env": {},
+    "log_to_stdout": true,
+    "extension_paths": [],
+    "allowed_args": {},
+    "headless": true,
+    "active": true,
+    "unresolved_command_path": "sleep",
+    "success_return_codes": [0],
+    "capacity_requirements": {},
+    "working_directory": "",
+    "container": "busybox:1.35"
+}

--- a/helm/nv.svc.farm/files/scripts/load_job_definitions.sh
+++ b/helm/nv.svc.farm/files/scripts/load_job_definitions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -e
+set -u
+
+echo "Starting job definition load script."
+
+echo "JOBS_API_URL: ${JOBS_API_URL}"
+echo "JOB_DEFINITIONS_DIR: ${JOB_DEFINITIONS_DIR}"
+
+echo "\nlisting all files under ${JOB_DEFINITIONS_DIR}\n"
+ls -la "${JOB_DEFINITIONS_DIR}"
+
+# Use a while loop instead of an array for portability
+find "${JOB_DEFINITIONS_DIR}" -type f -name "*.json" | while IFS= read -r file; do
+    echo "\n--\nuploading job definition: ${file}\n$(cat "$file")\n"
+
+    wget --quiet --output-document=/tmp/http_response --server-response \
+        --header="accept: application/json" \
+        --header="Content-Type: application/json" \
+        --header="X-API-KEY: ${JOBS_API_KEY}" \
+        --post-file="$file" \
+        "${JOBS_API_URL}/save"
+
+    echo "response:\n$(cat /tmp/http_response)"
+done
+
+echo "\n--\nchecking job definitions: ${JOBS_API_URL}/load"
+
+wget --quiet --output-document=/tmp/http_response --server-response \
+    --header="accept: application/json" \
+    --header="Content-Type: application/json" \
+    "${JOBS_API_URL}/load"
+
+echo "response:\n$(cat /tmp/http_response)"
+
+echo "\n\nDone."

--- a/helm/nv.svc.farm/templates/jobs/configmap-job-definitions.yaml
+++ b/helm/nv.svc.farm/templates/jobs/configmap-job-definitions.yaml
@@ -11,8 +11,9 @@
   {{- end }}
 {{- end }}
 
+{{- $extraJobDefinitions := $mergedJobsSvc.serviceConfig.extraJobDefinitions | default dict -}}
 
-{{- if $jobList -}}
+{{- if or $jobList $extraJobDefinitions -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,7 +23,14 @@ metadata:
 data:
 {{ (.Files.Glob "files/scripts/load_job_definitions.sh").AsConfig | indent 2 }}
 {{- range $item := $jobList }}
-  {{ ($.Files.Glob $item ).AsConfig | nindent 2}}
+  {{- $fileContents := $.Files.Glob $item }}
+  {{- if $fileContents }}
+  {{ $fileContents.AsConfig | nindent 2}}
+  {{- end }}
+{{- end }}
+{{- range $name, $content := $extraJobDefinitions }}
+  {{ $name }}: |
+    {{ $content | nindent 4 }}
 {{- end }}
 
 {{- end }}

--- a/helm/nv.svc.farm/values.yaml
+++ b/helm/nv.svc.farm/values.yaml
@@ -437,6 +437,19 @@ apps:
       definitions:
       - df
       - nvidia-smi-check
+      # -- Map of custom job definitions to load alongside the bundled ones.
+      # Keys are filenames (e.g. my-job.json), values are the raw JSON content.
+      # @section -- Jobs
+      # extraJobDefinitions:
+      #   my-job.json: |
+      #     {
+      #       "name": "my-job",
+      #       "job_type": "base",
+      #       "command": "echo",
+      #       "args": ["hello"],
+      #       "container": "ubuntu:24.04"
+      #     }
+      extraJobDefinitions: {}
     # Jobs Application Specific Settings/Overrides
     # @section -- Jobs
     settings:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
                                         
  - Add `files/job_definitions/` with bundled definitions: `df`, `echo`, `nvidia-smi-check`, `sleep-test`, `slack-webhook-message`                                                                                                                            
  - Add `files/scripts/load_job_definitions.sh`
  - Add `extraJobDefinitions` values key to support inline custom job definitions without forking the chart                                                                                                                                                   
  - Fix `configmap-job-definitions.yaml` to guard against `Files.Glob` returning empty results (rendered invalid `{}` in ConfigMap data block)